### PR TITLE
Add a placeholder to the Search field

### DIFF
--- a/app/views/refinery/acts_as_indexed/admin/_search.html.erb
+++ b/app/views/refinery/acts_as_indexed/admin/_search.html.erb
@@ -3,7 +3,7 @@
     :name => 'search',
     :value => params[:search],
     :title =>       t('search_input_help', :scope => 'refinery.admin.search', :query => h(params[:search])).html_safe,
-    :placeholder => t('search_input_notice', :scope => 'refinery.admin.search', :query => h(params[:search])).html_safe
+    :placeholder => t('search_input_placeholder', :scope => 'refinery.admin.search', :query => h(params[:search])).html_safe
     %>
   <%= hidden_field :visual_editor, nil, :name => 'visual_editor', :id => nil, :value => true  if params[:visual_editor].presence %>
   <%= hidden_field :dialog, nil, :name => 'dialog', :id => nil, :value => true if from_dialog? %>

--- a/app/views/refinery/acts_as_indexed/admin/_search.html.erb
+++ b/app/views/refinery/acts_as_indexed/admin/_search.html.erb
@@ -1,5 +1,10 @@
 <form method='GET' action='<%= url %>' class='search_form'>
-  <%= text_field :search, nil, :id => 'search', :type => 'search', :name => 'search', :value => params[:search], :title => t('search_input_notice', :scope => 'refinery.admin.search') %>
+  <%= text_field :search, nil, :id => 'search', :type => 'search',
+    :name => 'search',
+    :value => params[:search],
+    :title =>       t('search_input_help', :scope => 'refinery.admin.search', :query => h(params[:search])).html_safe,
+    :placeholder => t('search_input_notice', :scope => 'refinery.admin.search', :query => h(params[:search])).html_safe
+    %>
   <%= hidden_field :visual_editor, nil, :name => 'visual_editor', :id => nil, :value => true  if params[:visual_editor].presence %>
   <%= hidden_field :dialog, nil, :name => 'dialog', :id => nil, :value => true if from_dialog? %>
   <%= hidden_field :callback, nil, :name => 'callback', :id => nil, :value => @callback if @callback.presence %>


### PR DESCRIPTION
These changes are complements to PR #2960

1. Add placeholder
2. Make placeholder and title html_safe so that html entities can be
used.
3. New i18n string search_input_help used as tootip. Uses wording from
old search_input_notice