### PR TITLE
Avoid overriding user's indices

### DIFF
--- a/app/decorators/models/refinery/blog/category_decorator.rb
+++ b/app/decorators/models/refinery/blog/category_decorator.rb
@@ -2,7 +2,7 @@ require 'acts_as_indexed'
 
 begin
   Refinery::Blog::Category.class_eval do
-    acts_as_indexed :fields => [:title]
+    acts_as_indexed :fields => [:title] unless self.respond_to? :with_query
   end
 rescue NameError
 end

--- a/app/decorators/models/refinery/blog/comment_decorator.rb
+++ b/app/decorators/models/refinery/blog/comment_decorator.rb
@@ -2,7 +2,7 @@ require 'acts_as_indexed'
 
 begin
   Refinery::Blog::Comment.class_eval do
-    acts_as_indexed :fields => [:name, :email, :message]
+    acts_as_indexed :fields => [:name, :email, :message] unless self.respond_to? :with_query
   end
 rescue NameError
 end

--- a/app/decorators/models/refinery/blog/post_decorator.rb
+++ b/app/decorators/models/refinery/blog/post_decorator.rb
@@ -2,7 +2,7 @@ require 'acts_as_indexed'
 
 begin
   Refinery::Blog::Post.class_eval do
-    acts_as_indexed :fields => [:title, :custom_teaser, :body]
+    acts_as_indexed :fields => [:title, :custom_teaser, :body] unless self.respond_to? :with_query
   end
 rescue NameError
 end

--- a/app/decorators/models/refinery/image_decorator.rb
+++ b/app/decorators/models/refinery/image_decorator.rb
@@ -3,7 +3,7 @@ require 'acts_as_indexed'
 begin
   Refinery::Image.class_eval do
     # Docs for acts_as_indexed http://github.com/dougal/acts_as_indexed
-    acts_as_indexed :fields => [:title]
+    acts_as_indexed :fields => [:title] unless self.respond_to? :with_query
   end
 rescue NameError
 end

--- a/app/decorators/models/refinery/inquiries/inquiry_decorator.rb
+++ b/app/decorators/models/refinery/inquiries/inquiry_decorator.rb
@@ -2,7 +2,7 @@ require 'acts_as_indexed'
 
 begin
   Refinery::Inquiries::Inquiry.class_eval do
-    acts_as_indexed :fields => [:name, :email, :message, :phone]
+    acts_as_indexed :fields => [:name, :email, :message, :phone] unless self.respond_to? :with_query
   end
 rescue NameError
 end

--- a/app/decorators/models/refinery/page_decorator.rb
+++ b/app/decorators/models/refinery/page_decorator.rb
@@ -4,8 +4,11 @@ require 'stringex_lite'
 begin
   Refinery::Page.class_eval do
     # Docs for acts_as_indexed https://github.com/dougal/acts_as_indexed
-    acts_as_indexed :fields => [:ascii_title, :meta_description,
-                                :menu_title, :browser_title, :ascii_all_page_part_content]
+    unless self.respond_to? :with_query
+      acts_as_indexed :fields => [:ascii_title, :meta_description,
+                                  :menu_title, :browser_title,
+                                  :ascii_all_page_part_content]
+    end
 
     # Used to index all the content on this page so it can be easily searched.
     def all_page_part_content

--- a/app/decorators/models/refinery/resource_decorator.rb
+++ b/app/decorators/models/refinery/resource_decorator.rb
@@ -3,7 +3,7 @@ require 'acts_as_indexed'
 begin
   Refinery::Resource.class_eval do
     # Docs for acts_as_indexed http://github.com/dougal/acts_as_indexed
-    acts_as_indexed :fields => [:file_name, :title, :type_of_content]
+    acts_as_indexed :fields => [:file_name, :title, :type_of_content] unless self.respond_to? :with_query
   end
 rescue NameError
 end

--- a/app/decorators/models/refinery/setting_decorator.rb
+++ b/app/decorators/models/refinery/setting_decorator.rb
@@ -3,7 +3,7 @@ require 'acts_as_indexed'
 begin
   Refinery::Setting.class_eval do
     # Docs for acts_as_indexed http://github.com/dougal/acts_as_indexed
-    acts_as_indexed :fields => [:name]
+    acts_as_indexed :fields => [:name] unless self.respond_to? :with_query
   end
 rescue NameError
 end

--- a/app/decorators/models/refinery/user_decorator.rb
+++ b/app/decorators/models/refinery/user_decorator.rb
@@ -3,7 +3,7 @@ require 'acts_as_indexed'
 begin
   Refinery::Authentication::Devise::User.class_eval do
     # Docs for acts_as_indexed http://github.com/dougal/acts_as_indexed
-    acts_as_indexed :fields => [:username, :email]
+    acts_as_indexed :fields => [:username, :email] unless self.respond_to? :with_query
   end
 rescue NameError
 end


### PR DESCRIPTION
(depends on #15)

If we call `acts_as_indexed` for the models we know _after_ users have done so, we override their decisions (ie, the fields to index).

This PR skips calling `acts_as_indexed` if it has already been called.